### PR TITLE
shell-command-on-region fix (take 2)

### DIFF
--- a/dpaste.el
+++ b/dpaste.el
@@ -100,7 +100,8 @@ With a prefix argument, use hold option."
                                      " http://dpaste.com/api/v1/")
 			     output)
     (with-current-buffer output
-      (search-backward-regexp "^Location: \\(http://dpaste\\.com/\\(hold/\\)?[0-9]+/\\)")
+      (setq point (point-min))
+      (search-forward-regexp "^Location: \\(http://dpaste\\.com/\\(hold/\\)?[0-9]+/\\)")
       (message "Paste created: %s (yanked)" (match-string 1))
       (kill-new (match-string 1)))
     (kill-buffer output)))


### PR DESCRIPTION
Greg,

Sorry to submit a fix for the same issue, but I've found that two different emacs installations of mine behave differently.  This fix solves both scenarios.

I've seen some issues on different platforms where the with-current-buffer after shell-command-on-region will end up at the end of the resulting dpaste response, and other times it will be at the beginning.  This will reset the point to the beginning and do a proper forward search.

Thanks again,
Justin
