### PR TITLE
Use beginning-of-buffer rather than setq point

### DIFF
--- a/dpaste.el
+++ b/dpaste.el
@@ -100,7 +100,7 @@ With a prefix argument, use hold option."
                                      " http://dpaste.com/api/v1/")
 			     output)
     (with-current-buffer output
-      (setq point (point-min))
+      (beginning-of-buffer)
       (search-forward-regexp "^Location: \\(http://dpaste\\.com/\\(hold/\\)?[0-9]+/\\)")
       (message "Paste created: %s (yanked)" (match-string 1))
       (kill-new (match-string 1)))


### PR DESCRIPTION
In my version of emacs, dpaste.el did not work.  I fixed it by using beginning-of-buffer to move the point to the beginning of the dpaste output buffer rather than doing setq point.. not sure why setq point did not work, but beginning-of-buffer seems clearer anyway.

GNU Emacs 24.1.50.1 (x86_64-pc-linux-gnu, GTK+ Version 3.2.0) of 2012-07-28 on meitnerium, modified by Debian
